### PR TITLE
update return from `getPath` to fix local dev error

### DIFF
--- a/src/templates/search.tsx
+++ b/src/templates/search.tsx
@@ -10,7 +10,7 @@ import {
 import "../index.css";
 
 export const getPath: GetPath<TemplateProps> = () => {
-  return "/search";
+  return "search";
 };
 
 export const getHeadConfig: GetHeadConfig<


### PR DESCRIPTION
The forward slash breaks and should be avoided in the return values from `getPath`